### PR TITLE
Add "ContextTestCase" for easy assertion on contexts

### DIFF
--- a/automation_entities/context.py
+++ b/automation_entities/context.py
@@ -26,12 +26,27 @@ class Subcontext(object):
     #: the log position to save for the parent context
     log_position: typing.Optional[int]
 
+    already_entered: bool
+
     def __init__(self, context: "Context"):
         self.context = context
         self.log_position = None
+        self.already_entered = False
+
+    def log(self, msg: str) -> None:
+        """
+        Log given *msg* as a result of an interaction with this subcontext.
+        """
+        assert (
+            self.log_position is not None
+        ), "log must only be called in conjunction with __enter__"
+        self.context.log(msg)
 
     def __enter__(self) -> "Subcontext":
+        assert not self.already_entered, "a subcontext may only be entered once"
+
         self.log_position = self.context.log_position
+        self.already_entered = True
         self.context.log_position += 1
         return self
 

--- a/automation_entities/entities.py
+++ b/automation_entities/entities.py
@@ -26,12 +26,12 @@ def describe(fcn: Callable) -> Callable:
         arg_str = ", ".join(arg_toks)
         if len(arg_str) > 100:
             arg_str = arg_str[:97] + "..."
-        with self.context.subcontext(f"{fcn.__qualname__}({arg_str}):"):
+        with self.context.subcontext(f"{fcn.__qualname__}({arg_str}):") as sctx:
             ret = fcn(self, *args, **kwds)
             ret_str = repr(ret)
             if len(ret_str) > 100:
                 ret_str = ret_str[:97] + "..."
-            self.context.log(f"Return: {ret_str}")
+            sctx.log(f"Return: {ret_str}")
             return ret
 
     return inner
@@ -76,7 +76,7 @@ class SubInteraction(object):
         """
         log given *msg* as a result of an interaction with an entity
         """
-        self.context.log(f"{msg}")
+        self.subcontext.log(msg)
 
 
 class Entity(object):

--- a/automation_entities/test_context/__init__.py
+++ b/automation_entities/test_context/__init__.py
@@ -1,0 +1,1 @@
+from .context_test_case import ContextTestCase

--- a/automation_entities/test_context/context_test_case.py
+++ b/automation_entities/test_context/context_test_case.py
@@ -1,0 +1,148 @@
+import unittest
+from unittest.mock import MagicMock, create_autospec, call
+from ..context import Context
+from typing import List, NamedTuple, Iterator, Optional, Dict, Any
+from assertpy import assert_that
+
+
+class ContextTestCase(unittest.TestCase):
+    """
+    TestCase base class that presents an :attr:`context` and implements a
+    :meth:`assert_subcontext` method that can be used to assert that the
+    context itself created specific subcontexts.
+
+    .. autoattribute:: context
+
+    .. automethod:: assert_subcontext
+    """
+
+    #: mocked context
+    context: MagicMock
+
+    def setUp(self) -> None:
+        self.context = create_autospec(Context)
+
+    def assert_subcontexts(self, shb: List[Dict]) -> None:
+        """
+        Assert that the givn *shb* ``dict`` matches the discovered subcontext
+        data.
+        """
+        self.assertEqual(shb, [s.as_dict() for s in self.get_subcontext_comparisons()])
+
+    def get_subcontext_comparisons(self) -> List["SubcontextComparison"]:
+        """
+        Assert that the givn *shb* ``dict`` matches the discovered subcontext
+        data.
+        """
+        return SubcontextComparison.discover_from_calls(
+            self.context.subcontext.mock_calls.__iter__()
+        )
+
+
+class SubcontextComparison(NamedTuple):
+    #: The message given to create this subcontext
+    message: str
+    #: Subcontexts of this subcontext
+    subcontexts: List["SubcontextComparison"]
+    #: log messages left in this subcontext
+    log_messages: List[str]
+
+    @classmethod
+    def discover_from_calls(cls, calls: Iterator[Any]) -> List["SubcontextComparison"]:
+        """
+        Discover a :class:`SubcontextComparison` that can be asserted on from
+        the given *calls*.
+        """
+        ret = []
+        for c in calls:
+            message = cls.get_log_message(c)
+            ret.append(cls.discover_single(message, calls))
+
+        return ret
+
+    @classmethod
+    def discover_single(
+        cls, message: str, calls: Iterator[Any]
+    ) -> "SubcontextComparison":
+        """
+        Discover a :class:`SubcontextComparison` that can be asserted on from
+        the given *calls*.
+        """
+        self = cls(message=message, subcontexts=[], log_messages=[])
+        self.discover_subcontexts(calls)
+        return self
+
+    def discover_subcontexts(self, calls: Iterator[Any]) -> None:
+        """
+        Discover all subcontexts from *calls* and populate this object with
+        their data.
+        """
+        for c in calls:
+            if self.is_exit_call(c):
+                return
+
+            if self.is_enter_call(c):
+                continue
+
+            if self.is_log_call(c):
+                self.log_messages.append(self.get_log_message(c))
+
+            if self.is_subcontext_call(c):
+                message = self.get_log_message(c)
+                self.subcontexts.append(self.discover_single(message, calls))
+
+            # Ignore everything else. These MagicMock calls are pretty noisy,
+            # so I'm airing on the side of only discovering things that I care
+            # about.
+
+    @staticmethod
+    def is_enter_call(c: Any) -> bool:
+        """
+        Check and return if the given call *c* is a call to __enter__.
+        """
+        return f"{c}" == "call().__enter__()"
+
+    @staticmethod
+    def is_exit_call(c: Any) -> bool:
+        """
+        Check and return if the given call *c* is a call to __exit__.
+        """
+        return f"{c}".startswith("call().__exit__(")
+
+    @staticmethod
+    def is_log_call(c: Any) -> bool:
+        """
+        Check and return if the given call *c* is a call to log.
+        """
+        repr_val = f"{c}"
+        return repr_val.startswith("call().log(") or repr_val.startswith(
+            "call().__enter__().log("
+        )
+
+    @staticmethod
+    def is_subcontext_call(c: Any) -> bool:
+        """
+        Check and return if the given call *c* is a subcontext call.
+        """
+        return f"{c}".startswith("call('")
+
+    @staticmethod
+    def get_log_message(c: Any) -> str:
+        """
+        Return a given call's *c* log message.
+        """
+        assert_that(c.args).is_length(1)
+        return c.args[0]
+
+    def as_dict(self) -> Dict[str, Any]:
+        """
+        Represent this object as a ``dict``.
+        """
+        ret: Dict[str, Any] = {"message": self.message}
+        if len(self.subcontexts) > 0:
+            ret["subcontexts"] = [s.as_dict() for s in self.subcontexts]
+
+        if len(self.log_messages) > 0:
+            ret["log_messages"] = self.log_messages
+
+        return ret

--- a/automation_entities/test_context/test_subcontext.py
+++ b/automation_entities/test_context/test_subcontext.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import create_autospec
 
 from ..context import Context, Subcontext
 
@@ -14,13 +15,38 @@ class SubcontextTest(unittest.TestCase):
         self.assertEqual(self.context, subcontext.context)
         self.assertIsNone(subcontext.log_position)
 
+    def test_log_not_entered(self) -> None:
+        subcontext = Subcontext(self.context)
+        with self.assertRaisesRegex(
+            AssertionError, "log must only be called in conjunction with __enter__"
+        ):
+            subcontext.log("log message")
+
+    def test_log_entered(self) -> None:
+        mock_context = create_autospec(Context)
+
+        subcontext = Subcontext(mock_context)
+        subcontext.log_position = 1
+        subcontext.log("log message")
+
+        mock_context.log.assert_called_once_with("log message")
+
     def test_enter(self) -> None:
         subcontext = Subcontext(self.context)
         cmp_subcontext = subcontext.__enter__()
         self.assertEqual(subcontext, cmp_subcontext)
 
         self.assertEqual(0, subcontext.log_position)
+        self.assertTrue(subcontext.already_entered)
         self.assertEqual(1, self.context.log_position)
+
+    def test_cannot_reenter(self) -> None:
+        subcontext = Subcontext(self.context)
+        subcontext.already_entered = True
+        with self.assertRaisesRegex(
+            AssertionError, "a subcontext may only be entered once"
+        ):
+            cmp_subcontext = subcontext.__enter__()
 
     def test_exit_none_log_position(self) -> None:
         subcontext = Subcontext(self.context)

--- a/automation_entities/test_entities/test_sub_interaction.py
+++ b/automation_entities/test_entities/test_sub_interaction.py
@@ -2,14 +2,15 @@ import unittest
 from unittest.mock import MagicMock, create_autospec
 from ..context import Context, Subcontext
 from ..entities import Entity, SubInteraction
+from ..test_context import ContextTestCase
 
 
-class BaseTestCase(unittest.TestCase):
-    context: MagicMock
+class BaseTestCase(ContextTestCase):
     entity: Entity
 
     def setUp(self) -> None:
-        self.context = create_autospec(Context)
+        super().setUp()
+
         self.entity = create_autospec(Entity)
 
 
@@ -22,7 +23,13 @@ class TestInitialize(BaseTestCase):
             self.context.subcontext.return_value, sub_interaction.subcontext
         )
 
-        self.context.subcontext.assert_called_once_with("delim")
+        self.assert_subcontexts(
+            [
+                {
+                    "message": "delim",
+                }
+            ]
+        )
 
     def test_with_message(self) -> None:
         sub_interaction = SubInteraction(
@@ -34,7 +41,13 @@ class TestInitialize(BaseTestCase):
             self.context.subcontext.return_value, sub_interaction.subcontext
         )
 
-        self.context.subcontext.assert_called_once_with("delim interaction message")
+        self.assert_subcontexts(
+            [
+                {
+                    "message": "delim interaction message",
+                }
+            ]
+        )
 
 
 class SubInteractionTestCase(BaseTestCase):
@@ -68,4 +81,11 @@ class TestLog(SubInteractionTestCase):
     def test_log(self) -> None:
         self.sub_interaction.log("log message")
 
-        self.context.log.assert_called_once_with("log message")
+        self.assert_subcontexts(
+            [
+                {
+                    "message": "delim",
+                    "log_messages": ["log message"],
+                }
+            ]
+        )

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,4 +1,5 @@
 alabaster==0.7.13
+assertpy==1.1
 attrs==23.1.0
 Babel==2.13.1
 beautifulsoup4==4.12.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pip-check-updates>=0.23.0,<0.24 # compare installed versions to those in pypi
 mypy>=1.6.1,<1.7                # static type checking
 black>=23.10.1,<24              # code formatting
 pytest-cov>=4.1.0,<5            # run tests
+assertpy==1.1


### PR DESCRIPTION
- This change adds the new "ContextTextCase" as a helper base class for test cases that need a mocked context value. The purpose of this base class is to provide helper methods for asserting on how the context is used. I've mostly added this to test the "subcontext" mechanism to ensure the correct data was called.
- I also modified the subcontext mechanism a bit to make a little more sense.